### PR TITLE
Update log4p.py

### DIFF
--- a/log4p.py
+++ b/log4p.py
@@ -1,1 +1,1 @@
-log = eval
+log = exec


### PR DESCRIPTION
Change eval to exec

exec has more functionality
- eval only accepts single expressions, exec accepts valid python code
- exec can be used to assign a value to variable , but eval will throw an error

However, exec doesn't have a return value unlike eval